### PR TITLE
New feature for -cross and adding -member

### DIFF
--- a/commands/cross-roles.js
+++ b/commands/cross-roles.js
@@ -41,6 +41,8 @@ module.exports = {
 			console.log(role1,role2)
 			let memberwithrole1 = message.guild.roles.cache.get(roles[role1]).members
 			let memberwithrole2 = message.guild.roles.cache.get(roles[role2]).members
+			let countrole1 = memberwithrole1.size
+			let countrole2 = memberwithrole2.size
 			memberwithrole1.map( m => {
 				memberwithrole2.map( n =>{
 					if(m.user.username == n.user.username)
@@ -49,7 +51,9 @@ module.exports = {
 					}
 				})
 			})
-			returnEmbed.addField("Members with rank " + roles_name[role1] + " having rank " + roles_name[role2] + ":", count, true)
+			returnEmbed.addField("Members with rank " + roles_name[role1],countrole1,true)
+			returnEmbed.addField("Members with rank " + roles_name[role2],countrole2,true)
+			returnEmbed.addField("Members with rank " + roles_name[role1] + " having rank " + roles_name[role2], count)
 			message.channel.send(returnEmbed.setTimestamp());
 		} catch(err) {
 			message.channel.send(`Something went wrong: -cross ${role1} ${role2} \n ERROR: ${err}`)

--- a/commands/member.js
+++ b/commands/member.js
@@ -1,0 +1,93 @@
+const Discord = require("discord.js");
+const fs = require('fs')
+module.exports = {
+	name: 'member',
+	description: 'Lists the tag/username/id/nickname(default = nickname) of members with given role, limited to maxlength(default = 10) in embed.',
+    format: '"role" "tag/username/id/nickname" "maxlength"',
+	permlvl: 0,
+	restricted: false,
+    execute (message, args) {
+        try {
+			// Function to remove any ASCII characters that are not helpful, eg. - Magic spaces after progression ranks
+			// Also trims the spaces now.
+			function cleanString(input)
+			{
+				var output = "";
+				for(var i=0;i<input.length;i++)
+				{
+					if(input.charCodeAt(i)<=127)
+					{
+						output+=input.charAt(i);
+					}
+				}
+				return output.trim();
+			}
+			roles = {}
+			roles_name = {}
+			message.guild.roles.cache
+			.forEach(role => {
+				roles[cleanString(role.name.trim().toLowerCase().replace(/[.,\/#!$\^&\*;:{}=\-_`'~()]/g,""))] = role.id
+				roles_name[cleanString(role.name.trim().toLowerCase().replace(/[.,\/#!$\^&\*;:{}=\-_`'~()]/g,""))] = cleanString(role.name)
+			})
+            var role = args[0].toLowerCase().replace(/["'”“]/g,"").trim()
+            var type = ""
+            if(args[1] == undefined)
+            {
+                type = "nickname"
+            }
+            else
+            {
+                type = args[1].toLowerCase().replace(/["'”“]/g,"").trim()
+            }
+            var highlength = 0
+            if(args[2] == undefined)
+            {
+                highlength = 10
+            }
+            else
+            {
+                highlength = parseInt(args[2].replace(/["'”“]/g,"").trim())
+            }
+            let memberwithrole = message.guild.roles.cache.get(roles[role]).members
+            memberList = ""
+            memberwithrole.map(m => {
+                if(type == 'tag')
+                {
+                    memberList = memberList + m.user.tag + "\n"
+                }
+                if(type == 'username')
+                {
+                    memberList = memberList + m.user.username + "\n"
+                }
+                if(type == 'id')
+                {
+                    memberList = memberList + m.user.id + "\n"
+                }
+                if(type == 'nickname')
+                {
+                    memberList = memberList + m.displayName + "\n"
+                }
+            })
+            if(memberList.match(/[\n]/g).length <= highlength)
+            {
+                const returnEmbed = new Discord.MessageEmbed()
+			    .setColor('#FF7100')
+                .setAuthor('The Anti-Xeno Initiative', "https://cdn.discordapp.com/attachments/860453324959645726/865330887213842482/AXI_Insignia_Hypen_512.png")
+                .setTitle("**Member List**")
+                returnEmbed.addField("List of members holding rank " + roles_name[role] +":",memberList)
+                message.channel.send(returnEmbed.setTimestamp());
+            }
+            else
+            {
+                fs.writeFileSync('tmp/memberlist.txt', memberList); 
+                message.channel.send("Members List longer than "+highlength+"!\nSending the " + type +" in a txt file:",{
+                    files:[
+                        "tmp/memberlist.txt"
+                    ]
+                })
+            }
+        } catch(err) {
+			message.channel.send(`Something went wrong!\n ERROR: ${err}`)
+		}
+    }
+}


### PR DESCRIPTION
-cross
Now displays the number of individuals with both ranks first then the intersect count.

-member
Format: '"role" "tag/username/id/nickname" "maxlength"'
Lists the tag/username/id/nickname(type) of members with given role, limited to maxlength in embed.
tmp\memberlist.txt is a file that this command uses to store data. Whenever the command is used again, the txt file is overwritten.

Default type is set to "nickname".
Default maxlength is set to 10.