### PR TITLE
Fancy Quotes and txt defaults

### DIFF
--- a/commands/cross-roles.js
+++ b/commands/cross-roles.js
@@ -36,8 +36,8 @@ module.exports = {
 			//Following commented lines prints the whole dictionary/object created in above code.
 			//console.log(roles)
 			//console.log(roles_name)
-			var role1 = args[0].toLowerCase().replace(/["'”“]/g,"").trim()
-			var role2 = args[1].toLowerCase().replace(/["'”“]/g,"").trim()
+			var role1 = args[0].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
+			var role2 = args[1].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
 			console.log(role1,role2)
 			let memberwithrole1 = message.guild.roles.cache.get(roles[role1]).members
 			let memberwithrole2 = message.guild.roles.cache.get(roles[role2]).members

--- a/commands/cross-roles.js
+++ b/commands/cross-roles.js
@@ -38,7 +38,6 @@ module.exports = {
 			//console.log(roles_name)
 			var role1 = args[0].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
 			var role2 = args[1].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
-			console.log(role1,role2)
 			let memberwithrole1 = message.guild.roles.cache.get(roles[role1]).members
 			let memberwithrole2 = message.guild.roles.cache.get(roles[role2]).members
 			let countrole1 = memberwithrole1.size

--- a/commands/member.js
+++ b/commands/member.js
@@ -29,7 +29,8 @@ module.exports = {
 				roles[cleanString(role.name.trim().toLowerCase().replace(/[.,\/#!$\^&\*;:{}=\-_`'~()]/g,""))] = role.id
 				roles_name[cleanString(role.name.trim().toLowerCase().replace(/[.,\/#!$\^&\*;:{}=\-_`'~()]/g,""))] = cleanString(role.name)
 			})
-            var role = args[0].toLowerCase().replace(/["'”“]/g,"").trim()
+            var role = args[0].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
+            console.log(role)
             var mode = ""
             if(args[1] == undefined)
             {
@@ -37,7 +38,7 @@ module.exports = {
             }
             else
             {
-                mode = args[1].toLowerCase().replace(/["'”“]/g,"").trim()
+                mode = args[1].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
             }
             let memberwithrole = message.guild.roles.cache.get(roles[role]).members
             memberList = ""
@@ -50,7 +51,7 @@ module.exports = {
                 }
                 else
                 {
-                    type = args[2].toLowerCase().replace(/["'”“]/g,"").trim()
+                    type = args[2].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
                 }
                 var highlength = 0
                 if(args[3] == undefined)
@@ -59,7 +60,7 @@ module.exports = {
                 }
                 else
                 {
-                    highlength = parseInt(args[3].replace(/["'”“]/g,"").trim())
+                    highlength = parseInt(args[3].replace(/["'”`‛′’‘]/g,"").trim())
                 }
                 memberwithrole.map(m => 
                 {

--- a/commands/member.js
+++ b/commands/member.js
@@ -30,7 +30,15 @@ module.exports = {
 				roles_name[cleanString(role.name.trim().toLowerCase().replace(/[.,\/#!$\^&\*;:{}=\-_`'~()]/g,""))] = cleanString(role.name)
 			})
             var role = args[0].toLowerCase().replace(/["'”“]/g,"").trim()
-            var mode = args[1].toLowerCase().replace(/["'”“]/g,"").trim()
+            var mode = ""
+            if(args[1] == undefined)
+            {
+                mode = "txt"
+            }
+            else
+            {
+                mode = args[1].toLowerCase().replace(/["'”“]/g,"").trim()
+            }
             let memberwithrole = message.guild.roles.cache.get(roles[role]).members
             memberList = ""
             if(mode == "txt")
@@ -101,7 +109,6 @@ module.exports = {
                                 memberList = memberList + m.user.tag + "," + m.user.username + "," + m.user.id + "," +  m.displayName + "\n"
  
                         })
-                    console.log(memberList)
                     fs.writeFileSync('tmp/memberlist.csv',memberList)
                     message.channel.send("Here's your CSV file:",{
                         files:[

--- a/commands/member.js
+++ b/commands/member.js
@@ -30,7 +30,6 @@ module.exports = {
 				roles_name[cleanString(role.name.trim().toLowerCase().replace(/[.,\/#!$\^&\*;:{}=\-_`'~()]/g,""))] = cleanString(role.name)
 			})
             var role = args[0].toLowerCase().replace(/["'”`‛′’‘]/g,"").trim()
-            console.log(role)
             var mode = ""
             if(args[1] == undefined)
             {

--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ discordClient.once("ready", () => {
 discordClient.on('message', message => {
 	if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-	const args = message.content.slice(prefix.length).trim().match(/(?:[^\s"]+|"[^"]*")+/g); // Format Arguments
+	const args = message.content.replace(/[”]/g,`"`).slice(prefix.length).trim().match(/(?:[^\s"]+|"[^"]*")+/g); // Format Arguments
 	const commandName = args.shift().toLowerCase(); // Convert command to lowercase and remove first string in args (command)
   const command = discordClient.commands.get(commandName); // Gets the command inf
 


### PR DESCRIPTION
members command
- txt is now a default value, allowing you to only give the role name as input.
- removed debug console.logs

cross-join and members
- updated the regex to deal with some more fancy double quotes
- removed debug console.logs

index.js
- fixed a bug that caused text with spaces in fancy quotes to get cut off at the space. (`”role x”` would pass on `”role` as the argument.)